### PR TITLE
Correctly handle mute updates

### DIFF
--- a/co.meldstudio.streamdeck.sdPlugin/README.md
+++ b/co.meldstudio.streamdeck.sdPlugin/README.md
@@ -39,7 +39,7 @@ hi@meldstudio.co
 - Use new setMuted method to avoid depreciated setProperty call on "muted" AudioTrack properties.
 
 
-## 2025-01-30 (v0.5.0.0)
+## 2025-01-30 (v0.5.0.1)
 ### Changes:
 -----------
 - Added support for Clip action.

--- a/co.meldstudio.streamdeck.sdPlugin/README.md
+++ b/co.meldstudio.streamdeck.sdPlugin/README.md
@@ -12,10 +12,8 @@ And we're not done yet! We are continually working to bring you even more capabi
 
 ## What's New
 
-Version 0.5.0.1
-Add Clip action for clipping the last 90 seconds into recording.
-Fix for dial press on the Stream Deck+.
-Fix for mute/cue responsiveness issues.
+Version 0.5.1.0
+- Use new setMuted method to avoid depreciated setProperty call on "muted" AudioTrack properties.
 
 ## Helpful Links
 
@@ -34,6 +32,12 @@ hi@meldstudio.co
 ------------
 # Change History:
 ------------
+
+## 2025-07-11 (v0.5.1.0)
+### Changes:
+-----------
+- Use new setMuted method to avoid depreciated setProperty call on "muted" AudioTrack properties.
+
 
 ## 2025-01-30 (v0.5.0.0)
 ### Changes:

--- a/co.meldstudio.streamdeck.sdPlugin/actions/toggle-mute/plugin.js
+++ b/co.meldstudio.streamdeck.sdPlugin/actions/toggle-mute/plugin.js
@@ -28,7 +28,10 @@ class ToggleMute extends MeldStudioPlugin {
         // 1    | 1     | 0
         // 0    | 0     | 0
 
-        if ($MS.meld?.setProperty) {
+        if ($MS.meld?.setMuted) {
+          $MS.meld.setMuted(track, action_mute);
+          this.setLocalState(context, action_mute);
+        } else if ($MS.meld?.setProperty) {
           $MS.meld.setProperty(track, "muted", action_mute);
           this.setLocalState(context, action_mute);
         } else {

--- a/co.meldstudio.streamdeck.sdPlugin/manifest.json
+++ b/co.meldstudio.streamdeck.sdPlugin/manifest.json
@@ -8,7 +8,7 @@
 	"CodePath": "app.html",
 	"Description": "Meld Studio 💙 Stream Deck. Take your stream to new heights with powerful new capabilities at your fingertips. Trigger transitions, manage audio tracks, toggle filter effects on and off, and much more.",
 	"URL": "https://meldstudio.co",
-	"Version": "0.5.0.1",
+	"Version": "0.5.1.0",
 	"UUID": "co.meldstudio.streamdeck",
 	"OS": [
 		{


### PR DESCRIPTION
AudioTracks |muted| property was made `readonly` in Meld Studio as updates to this property should go through the `AudioTrackSceneMatrixModel` now. This broke the Stream Decks set muted / unmuted logic. This updates our streamdeck plugin to use the new `setMuted` method instead.

@zv1n I made this a minor version update, if it should be a patch version update just let me know.